### PR TITLE
Add Zar's boots, fix JSON Schema warnings

### DIFF
--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -318,27 +318,28 @@
                 "tools": [
                     "gunsmithing tools",
                     "one artisan tool or instrument of your choice"
+                ],
+                "skills": [
+                    {
+                        "choose": {
+                            "from": [
+                                "acrobatics",
+                                "arcana",
+                                "athletics",
+                                "insight",
+                                "intimidation",
+                                "perception",
+                                "persuasion",
+                                "sleight of hand",
+                                "survival"
+                            ],
+                            "count": 3
+                        }
+                    }
                 ]
             },
-            "skills": [
-                {
-                    "choose": {
-                        "from": [
-                            "acrobatics",
-                            "arcana",
-                            "athletics",
-                            "insight",
-                            "intimidation",
-                            "perception",
-                            "persuasion",
-                            "sleight of hand",
-                            "survival"
-                        ],
-                        "count": 3
-                    }
-                }
-            ],
             "startingEquipment": {
+                "additionalFromBackground": true,
                 "default": [
                     "a martial melee weapon",
                     "a tier 1 firearm with 20 bullets and 1 clip if applicable",

--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -15154,7 +15154,7 @@
                     "type": "table",
                     "caption": "Hover Material Table",
                     "colLabels": [
-                        "STerrain Type",
+                        "Terrain Type",
                         "Fly Speed",
                         "AFly Height"
                     ],

--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -11826,7 +11826,7 @@
             "entries": [
                 "As your skills improve, you learn to modify your Shotgun. As your Gun Tier levels up, your weapon is upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. If you lose or need to replace your special firearm, you can spend 1 hour per Tier it was crafting a new one, and the combined gold cost.",
                 {
-                    "title": "Buckshot Firearms",
+                    "caption": "Buckshot Firearms",
                     "type": "table",
                     "colLabels": [
                         "Firearm",
@@ -11993,7 +11993,7 @@
             "entries": [
                 "As your skills improve, you learn to modify your Blast Gun. As your Gun Tier levels up, your weapon is upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. The Blast Gun has unique modifications, which are unlocked at level 5, and these modifications can be upgraded at level 13 by paying the gold cost and spending 4 hours of work. These modifications can be attacked to the Blast Gun to allow it to perform new attacks. These new attacks have separate ranges, damage types, and use their own ammunition.",
                 {
-                    "title": "Demolitionist Firearms",
+                    "caption": "Demolitionist Firearms",
                     "type": "table",
                     "colLabels": [
                         "Firearm",
@@ -12054,7 +12054,7 @@
                     ]
                 },
                 {
-                    "title": "Blast Gun Modifications - Minigun",
+                    "caption": "Blast Gun Modifications - Minigun",
                     "type": "table",
                     "colLabels": [
                         "Firearm",
@@ -12100,7 +12100,7 @@
                     ]
                 },
                 {
-                    "title": "Blast Gun Modifications - Explosive Lobber",
+                    "caption": "Blast Gun Modifications - Explosive Lobber",
                     "type": "table",
                     "colLabels": [
                         "Firearm",
@@ -12146,7 +12146,7 @@
                     ]
                 },
                 {
-                    "title": "Blast Gun Modifications - Flamethrower",
+                    "caption": "Blast Gun Modifications - Flamethrower",
                     "type": "table",
                     "colLabels": [
                         "Firearm",
@@ -12315,7 +12315,7 @@
                 "Prepared Hexed Bullets are placed in a magical receptacle, such as an enchanted bandolier, a special clip, or other magical storage device. As a free action once per turn when you make a ranged weapon attack with a firearm, you can cause one of the prepared Hexed Bullets to teleport into your firearm, enhancing your next attack with that Hexed Bullets effects, and consuming one use of your Hexed Bullets.",
                 "Whenever you gain another Gunner level, you can replace a known Hexed Bullet option with another.",
                 {
-                    "title": "Hexlock Spellcasting",
+                    "caption": "Hexlock Spellcasting",
                     "type": "table",
                     "colLabels": [
                         "Name",
@@ -12481,7 +12481,7 @@
                 "At 2nd level, you choose an arcane discipline to learn from to enchant your firearms. You gain proficiency in either Nature, Religion, or Arcana, and your proficiency bonus for that skill is doubled. Depending on your choice, you unlock a unique Hexed Bullet the Pact Magic feature. If you choose Nature, your spell list is from the Druid and Ranger list, if you chose Religion your spell list is from the Cleric and Paladin list, and if you chose Arcana your spell list is from the Wizard and Artificer list. Regardless of your choice, your spell casting modifier is Intelligence.",
                 "At certain level, when you gain new Hexed Bullets you automatically learn the ones associated with your spellcasting list.",
                 {
-                    "title": "Hexlock Spellcasting",
+                    "caption": "Hexlock Spellcasting",
                     "type": "table",
                     "colLabels": [
                         "Gunner Level",
@@ -12745,7 +12745,7 @@
             "entries": [
                 "As your skills improve, you learn to modify your Revolvers. As your Gun Tier levels up, both of your weapons are upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. If you lose or need to replace your special firearms, you can spend 1 hour per Tier it was by crafting a new pair, and the combined gold cost. Both of the dual firearms the Quickdraw gains from this class can be equipped with unique Modifications. Though Revolvers can be crafted together, they are treated as individual weapons for things such as Rare Metal Crafting, Enchanting, etc.",
                 {
-                    "title": "Quickdraw Firearms",
+                    "caption": "Quickdraw Firearms",
                     "type": "table",
                     "colLabels": [
                         "Firearm",
@@ -12963,7 +12963,7 @@
             "entries": [
                 "As your skills improve, you learn to modify your Sniper. As your Gun Tier levels up, your weapon is upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. If you lose or need to replace your special firearm, you can spend 1 hour per Tier it was crafting a new one, and the combined gold cost.",
                 {
-                    "title": "Sniper Firearms",
+                    "caption": "Sniper Firearms",
                     "type": "table",
                     "colLabels": [
                         "Firearm",

--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -15118,28 +15118,24 @@
             "entries": [
                 "At 6th level, you can select a unique way to manifest your magical powers. Select either Molten Core or Static Core, and you gain features based off what you selected.",
                 {
+                    "type": "inset",
+                    "name": "Molten Core",
                     "entries": [
-                        {
-                            "type": "inset",
-                            "name": "Molten Core",
-                            "entries": [
-                                "You gain resistance to Fire damage. You learn the Heat Metal spell, it counts as a Sorcerer spell for you, and can cast it a number of times equal to your Charisma Modifier per long rest. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Fire Damage, as the metal burns them."
-                            ]
-                        },
-                        {
-                            "type": "inset",
-                            "name": "Static Core",
-                            "entries": [
-                                "You gain resistance to Lightning damage. Whenever you cast a Sorcerer spell that deals Lightning Damage, your Magnetic Surge's weight maximum is doubled and creatures affected by it have disadvantage on the Strength Saving Throw. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Lightning Damage, as the metal shocks them."
-                            ]
-                        },
-                        {
-                            "type": "inset",
-                            "name": "Static Core",
-                            "entries": [
-                                "You gain resistance to Acid damage. Creatures of your choice that would be disarmed or moved by your Magnetic Surge, you can reduce their Armor class by 1d4 or their attack rolls by 1d4, so long as you are targetting armor/weapon made of metal. This reduction lasts until the start of your next turn. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Acid Damage, as the metal burns them."
-                            ]
-                        }
+                        "You gain resistance to Fire damage. You learn the Heat Metal spell, it counts as a Sorcerer spell for you, and can cast it a number of times equal to your Charisma Modifier per long rest. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Fire Damage, as the metal burns them."
+                    ]
+                },
+                {
+                    "type": "inset",
+                    "name": "Static Core",
+                    "entries": [
+                        "You gain resistance to Lightning damage. Whenever you cast a Sorcerer spell that deals Lightning Damage, your Magnetic Surge's weight maximum is doubled and creatures affected by it have disadvantage on the Strength Saving Throw. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Lightning Damage, as the metal shocks them."
+                    ]
+                },
+                {
+                    "type": "inset",
+                    "name": "Static Core",
+                    "entries": [
+                        "You gain resistance to Acid damage. Creatures of your choice that would be disarmed or moved by your Magnetic Surge, you can reduce their Armor class by 1d4 or their attack rolls by 1d4, so long as you are targetting armor/weapon made of metal. This reduction lasts until the start of your next turn. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Acid Damage, as the metal burns them."
                     ]
                 }
             ]

--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -1742,8 +1742,7 @@
             "range": "100/400",
             "dmg1": "1d10",
             "dmgType": "P",
-            "crossbow": true,
-            "weapon": true,
+            "foundryType": "weapon",
             "ammoType": "crossbow bolt|phb",
             "entries": [
                 "<i><b>Simple Invention.</i></b>",

--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -6216,39 +6216,6 @@
                 "At 9th level they gain the ability to cast Wind Wall without expending a spell slot.",
                 "Once they have casted any of the three spells with this feature they cannot do so again until finish a long rest.",
                 "Your casting ability for these spells is Wisdom."
-            ],
-            "additionalSpells": [
-                {
-                    "innate": {
-                        "3": {
-                            "daily": {
-                                "1": [
-                                    "feather fall|PHB"
-                                ]
-                            }
-                        },
-                        "5": {
-                            "daily": {
-                                "1": [
-                                    "warding wind|XGE"
-                                ]
-                            }
-                        },
-                        "9": {
-                            "daily": {
-                                "1": [
-                                    "wind Wall|PHB"
-                                ]
-                            }
-                        }
-                    },
-                    "ability": "wis"
-                }
-            ],
-            "languageProficiencies": [
-                {
-                    "druidic": true
-                }
             ]
         },
         {

--- a/Tales_from_the_Jaazdin_Collective.json
+++ b/Tales_from_the_Jaazdin_Collective.json
@@ -14,11 +14,11 @@
                     "Agusia Krzywinska",
                     "Adam Henderson"
                 ],
-                "version": "0.1.1"
+                "version": "0.1.2"
             }
         ],
         "dateAdded": 0,
-        "dateLastModified": 1726107326
+        "dateLastModified": 1726172147
     },
     "background": [
         {
@@ -5007,6 +5007,21 @@
                 "<b><i>Tier 4.</i></b>",
                 "<b><i>Auto</i><b> Auto firearms can make an additional attack as a part of the Attack Action.",
                 "<b><i>Clip 6.</i></b> Whenever you craft a firearm that uses a clip, you additionally craft 2 clips. A Clip holds a number of shots detailed on the Firearms chart. To reload a Clip, you can use a Bonus Action to replace your current clip with another loaded clip. A clip can be loaded with its maximum number of rounds by spending 1 minute."
+            ]
+        },
+        {
+            "name": "Zar's Fancy Boots",
+            "source": "TftJC",
+            "rarity": "none",
+            "baseItem": "Common Clothes|PHB",
+            "type": "G",
+            "modifySpeed": {
+                "bonus": {
+                    "walk": 5
+                }
+            },
+            "entries": [
+                "These boots were hand made to your specification by Zar'ryath. While wearing these boots, your walking speed increases by 5 feet."
             ]
         },
         {

--- a/class/Gunner.json
+++ b/class/Gunner.json
@@ -170,27 +170,28 @@
         "tools": [
             "gunsmithing tools",
             "one artisan tool or instrument of your choice"
+        ],
+        "skills": [
+            {
+                "choose": {
+                    "from": [
+                        "acrobatics",
+                        "arcana",
+                        "athletics",
+                        "insight",
+                        "intimidation",
+                        "perception",
+                        "persuasion",
+                        "sleight of hand",
+                        "survival"
+                    ],
+                    "count": 3
+                }
+            }
         ]
     },
-    "skills": [
-        {
-            "choose": {
-                "from": [
-                    "acrobatics",
-                    "arcana",
-                    "athletics",
-                    "insight",
-                    "intimidation",
-                    "perception",
-                    "persuasion",
-                    "sleight of hand",
-                    "survival"
-                ],
-                "count": 3
-            }
-        }
-    ],
     "startingEquipment": {
+        "additionalFromBackground": true,
         "default": [
             "a martial melee weapon",
             "a tier 1 firearm with 20 bullets and 1 clip if applicable",

--- a/item/Adventuring Gear/Zar's Fancy Boots.json
+++ b/item/Adventuring Gear/Zar's Fancy Boots.json
@@ -1,0 +1,15 @@
+{
+    "name": "Zar's Fancy Boots",
+    "source": "TftJC",
+    "rarity": "none",
+    "baseItem": "Common Clothes|PHB",
+    "type": "G",
+    "modifySpeed": {
+        "bonus": {
+            "walk": 5
+        }
+    },
+    "entries": [
+        "These boots were hand made to your specification by Zar'ryath. While wearing these boots, your walking speed increases by 5 feet."
+    ]
+}

--- a/item/Ranged Weapon/Cross-Shield.json
+++ b/item/Ranged Weapon/Cross-Shield.json
@@ -16,8 +16,7 @@
     "range": "100/400",
     "dmg1": "1d10",
     "dmgType": "P",
-    "crossbow": true,
-    "weapon": true,
+    "foundryType": "weapon",
     "ammoType": "crossbow bolt|phb",
     "entries": [
         "<i><b>Simple Invention.</i></b>",

--- a/reward/Elemental Gift/Speaker of the Wind.json
+++ b/reward/Elemental Gift/Speaker of the Wind.json
@@ -10,38 +10,5 @@
         "At 9th level they gain the ability to cast Wind Wall without expending a spell slot.",
         "Once they have casted any of the three spells with this feature they cannot do so again until finish a long rest.",
         "Your casting ability for these spells is Wisdom."
-    ],
-    "additionalSpells": [
-        {
-            "innate": {
-                "3": {
-                    "daily": {
-                        "1": [
-                            "feather fall|PHB"
-                        ]
-                    }
-                },
-                "5": {
-                    "daily": {
-                        "1": [
-                            "warding wind|XGE"
-                        ]
-                    }
-                },
-                "9": {
-                    "daily": {
-                        "1": [
-                            "wind Wall|PHB"
-                        ]
-                    }
-                }
-            },
-            "ability": "wis"
-        }
-    ],
-    "languageProficiencies": [
-        {
-            "druidic": true
-        }
     ]
 }

--- a/subclassFeature/Buckshot/Shotgun Progression.json
+++ b/subclassFeature/Buckshot/Shotgun Progression.json
@@ -9,7 +9,7 @@
     "entries": [
         "As your skills improve, you learn to modify your Shotgun. As your Gun Tier levels up, your weapon is upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. If you lose or need to replace your special firearm, you can spend 1 hour per Tier it was crafting a new one, and the combined gold cost.",
         {
-            "title": "Buckshot Firearms",
+            "caption": "Buckshot Firearms",
             "type": "table",
             "colLabels": [
                 "Firearm",

--- a/subclassFeature/Demolitionist/Blast Gun Progression.json
+++ b/subclassFeature/Demolitionist/Blast Gun Progression.json
@@ -9,7 +9,7 @@
     "entries": [
         "As your skills improve, you learn to modify your Blast Gun. As your Gun Tier levels up, your weapon is upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. The Blast Gun has unique modifications, which are unlocked at level 5, and these modifications can be upgraded at level 13 by paying the gold cost and spending 4 hours of work. These modifications can be attacked to the Blast Gun to allow it to perform new attacks. These new attacks have separate ranges, damage types, and use their own ammunition.",
         {
-            "title": "Demolitionist Firearms",
+            "caption": "Demolitionist Firearms",
             "type": "table",
             "colLabels": [
                 "Firearm",
@@ -70,7 +70,7 @@
             ]
         },
         {
-            "title": "Blast Gun Modifications - Minigun",
+            "caption": "Blast Gun Modifications - Minigun",
             "type": "table",
             "colLabels": [
                 "Firearm",
@@ -116,7 +116,7 @@
             ]
         },
         {
-            "title": "Blast Gun Modifications - Explosive Lobber",
+            "caption": "Blast Gun Modifications - Explosive Lobber",
             "type": "table",
             "colLabels": [
                 "Firearm",
@@ -162,7 +162,7 @@
             ]
         },
         {
-            "title": "Blast Gun Modifications - Flamethrower",
+            "caption": "Blast Gun Modifications - Flamethrower",
             "type": "table",
             "colLabels": [
                 "Firearm",

--- a/subclassFeature/Hexlock/Hexed Bullets.json
+++ b/subclassFeature/Hexlock/Hexed Bullets.json
@@ -11,7 +11,7 @@
         "Prepared Hexed Bullets are placed in a magical receptacle, such as an enchanted bandolier, a special clip, or other magical storage device. As a free action once per turn when you make a ranged weapon attack with a firearm, you can cause one of the prepared Hexed Bullets to teleport into your firearm, enhancing your next attack with that Hexed Bullets effects, and consuming one use of your Hexed Bullets.",
         "Whenever you gain another Gunner level, you can replace a known Hexed Bullet option with another.",
         {
-            "title": "Hexlock Spellcasting",
+            "caption": "Hexlock Spellcasting",
             "type": "table",
             "colLabels": [
                 "Name",

--- a/subclassFeature/Hexlock/Magical Acolyte.json
+++ b/subclassFeature/Hexlock/Magical Acolyte.json
@@ -10,7 +10,7 @@
         "At 2nd level, you choose an arcane discipline to learn from to enchant your firearms. You gain proficiency in either Nature, Religion, or Arcana, and your proficiency bonus for that skill is doubled. Depending on your choice, you unlock a unique Hexed Bullet the Pact Magic feature. If you choose Nature, your spell list is from the Druid and Ranger list, if you chose Religion your spell list is from the Cleric and Paladin list, and if you chose Arcana your spell list is from the Wizard and Artificer list. Regardless of your choice, your spell casting modifier is Intelligence.",
         "At certain level, when you gain new Hexed Bullets you automatically learn the ones associated with your spellcasting list.",
         {
-            "title": "Hexlock Spellcasting",
+            "caption": "Hexlock Spellcasting",
             "type": "table",
             "colLabels": [
                 "Gunner Level",

--- a/subclassFeature/Ironhide/Magnetic Hover.json
+++ b/subclassFeature/Ironhide/Magnetic Hover.json
@@ -12,7 +12,7 @@
             "type": "table",
             "caption": "Hover Material Table",
             "colLabels": [
-                "STerrain Type",
+                "Terrain Type",
                 "Fly Speed",
                 "AFly Height"
             ],

--- a/subclassFeature/Ironhide/Power Core.json
+++ b/subclassFeature/Ironhide/Power Core.json
@@ -9,28 +9,24 @@
     "entries": [
         "At 6th level, you can select a unique way to manifest your magical powers. Select either Molten Core or Static Core, and you gain features based off what you selected.",
         {
+            "type": "inset",
+            "name": "Molten Core",
             "entries": [
-                {
-                    "type": "inset",
-                    "name": "Molten Core",
-                    "entries": [
-                        "You gain resistance to Fire damage. You learn the Heat Metal spell, it counts as a Sorcerer spell for you, and can cast it a number of times equal to your Charisma Modifier per long rest. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Fire Damage, as the metal burns them."
-                    ]
-                },
-                {
-                    "type": "inset",
-                    "name": "Static Core",
-                    "entries": [
-                        "You gain resistance to Lightning damage. Whenever you cast a Sorcerer spell that deals Lightning Damage, your Magnetic Surge's weight maximum is doubled and creatures affected by it have disadvantage on the Strength Saving Throw. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Lightning Damage, as the metal shocks them."
-                    ]
-                },
-                {
-                    "type": "inset",
-                    "name": "Static Core",
-                    "entries": [
-                        "You gain resistance to Acid damage. Creatures of your choice that would be disarmed or moved by your Magnetic Surge, you can reduce their Armor class by 1d4 or their attack rolls by 1d4, so long as you are targetting armor/weapon made of metal. This reduction lasts until the start of your next turn. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Acid Damage, as the metal burns them."
-                    ]
-                }
+                "You gain resistance to Fire damage. You learn the Heat Metal spell, it counts as a Sorcerer spell for you, and can cast it a number of times equal to your Charisma Modifier per long rest. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Fire Damage, as the metal burns them."
+            ]
+        },
+        {
+            "type": "inset",
+            "name": "Static Core",
+            "entries": [
+                "You gain resistance to Lightning damage. Whenever you cast a Sorcerer spell that deals Lightning Damage, your Magnetic Surge's weight maximum is doubled and creatures affected by it have disadvantage on the Strength Saving Throw. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Lightning Damage, as the metal shocks them."
+            ]
+        },
+        {
+            "type": "inset",
+            "name": "Static Core",
+            "entries": [
+                "You gain resistance to Acid damage. Creatures of your choice that would be disarmed or moved by your Magnetic Surge, you can reduce their Armor class by 1d4 or their attack rolls by 1d4, so long as you are targetting armor/weapon made of metal. This reduction lasts until the start of your next turn. Creatures of your choice that would be moved or disarmed by Magnetic Surge take {@dice 2d4} Acid Damage, as the metal burns them."
             ]
         }
     ]

--- a/subclassFeature/Quickdraw/Revolver Progression.json
+++ b/subclassFeature/Quickdraw/Revolver Progression.json
@@ -9,7 +9,7 @@
     "entries": [
         "As your skills improve, you learn to modify your Revolvers. As your Gun Tier levels up, both of your weapons are upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. If you lose or need to replace your special firearms, you can spend 1 hour per Tier it was by crafting a new pair, and the combined gold cost. Both of the dual firearms the Quickdraw gains from this class can be equipped with unique Modifications. Though Revolvers can be crafted together, they are treated as individual weapons for things such as Rare Metal Crafting, Enchanting, etc.",
         {
-            "title": "Quickdraw Firearms",
+            "caption": "Quickdraw Firearms",
             "type": "table",
             "colLabels": [
                 "Firearm",

--- a/subclassFeature/Sniper/Sniper Progression.json
+++ b/subclassFeature/Sniper/Sniper Progression.json
@@ -9,7 +9,7 @@
     "entries": [
         "As your skills improve, you learn to modify your Sniper. As your Gun Tier levels up, your weapon is upgraded into its next tier by paying for the upgrade cost and spending 1 hour using your Gunsmith's Tools. If you lose or need to replace your special firearm, you can spend 1 hour per Tier it was crafting a new one, and the combined gold cost.",
         {
-            "title": "Sniper Firearms",
+            "caption": "Sniper Firearms",
             "type": "table",
             "colLabels": [
                 "Firearm",


### PR DESCRIPTION
I verified this doesn't break anything. Schema errors could cause issues with the foundry importer, but were mostly visual on 5eTools, such as table headers